### PR TITLE
Fix project name for zephyr-battery example

### DIFF
--- a/examples/zephyr-battery/zephyr/CMakeLists.txt
+++ b/examples/zephyr-battery/zephyr/CMakeLists.txt
@@ -3,6 +3,6 @@ set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(blinky)
+project(battery)
 
 target_sources(app PRIVATE ../src/main.c)


### PR DESCRIPTION
Fix project name for zephyr-battery example