### PR TITLE
Add `nfct` to xiao_nrf54l15_nrf54l15_cpuapp.overlay

### DIFF
--- a/zephyr/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
+++ b/zephyr/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
@@ -13,3 +13,6 @@ dmic_dev: &pdm20 {
     status = "okay";
 };
 
+&nfct {
+	status = “okay”;
+};


### PR DESCRIPTION

https://forum.seeedstudio.com/t/error-building-matter-sample-for-xiao-nrf54l15-board/293520/63?u=lboue