### PR TITLE
fix: resolve script directory path through symlinks

### DIFF
--- a/scripts/factory_reset/factory_reset.sh
+++ b/scripts/factory_reset/factory_reset.sh
@@ -5,7 +5,7 @@ set -e
 # Factory reset wrapper (Linux/macOS)
 # ==============================================
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 FIRMWARE="${DIR}/firmware.hex"
 VENV_DIR="$DIR/.venv"
 DEP_MARKER="$VENV_DIR/.deps_installed"

--- a/scripts/factory_reset/recover_only.sh
+++ b/scripts/factory_reset/recover_only.sh
@@ -6,7 +6,7 @@ set -e
 # Always uses a dedicated virtual environment
 # ==============================================
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 VENV_DIR="$DIR/.venv"
 DEP_MARKER="$VENV_DIR/.deps_installed"
 REQ_PROBE="$1"


### PR DESCRIPTION
Executing the script via a symlink failed because
`dirname "${BASH_SOURCE[0]}"` evaluated to the symlink's location rather than the target script's directory.

Wrapped the source path in `realpath` to ensure the correct base directory is always resolved before execution.

This allows users to symlink those scripts for quick use, for example:

`ln -s ~/platform-seeedboards/scripts/factory_reset/recover_only.sh ~/.local/bin/nrf54l15_recover.sh`