### PR TITLE
fix: auto-install intelhex dependency for esptoolpy

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -137,24 +137,32 @@ class SeeedstudioPlatform(PlatformBase):
         python_exe = get_pythonexe_path()
         if not python_exe:
             return
-        try:
-            import rich_click  # pylint: disable=unused-import,import-outside-toplevel
-        except ImportError:
+
+        for module_name, pip_spec in [
+            ("rich_click", "rich_click<2"),
+            ("intelhex", "intelhex"),
+        ]:
             try:
-                subprocess.run(
-                    [
-                        python_exe,
-                        "-m",
-                        "pip",
-                        "install",
-                        "rich_click<2",
-                        "--disable-pip-version-check",
-                        "--no-input",
-                    ],
-                    check=True,
-                )
-            except Exception as e:
-                print(f"Warning: failed to install rich_click for esptoolpy: {e}")
+                __import__(module_name)
+            except ImportError:
+                try:
+                    subprocess.run(
+                        [
+                            python_exe,
+                            "-m",
+                            "pip",
+                            "install",
+                            pip_spec,
+                            "--disable-pip-version-check",
+                            "--no-input",
+                        ],
+                        check=True,
+                    )
+                except Exception as e:
+                    print(
+                        "Warning: failed to install %s for esptoolpy: %s"
+                        % (module_name, e)
+                    )
 
     def _get_packages_dir(self):
         config = ProjectConfig.get_instance()


### PR DESCRIPTION
## Summary

- Auto-install `intelhex` Python module alongside existing `rich_click` when building for ESP32 boards
- Refactors `_ensure_esptoolpy_runtime_dependencies()` into a loop to handle multiple dependencies generically
- Uses `__import__()` instead of hardcoded import for flexibility

Fixes #43

## Test plan

- [ ] Build an ESP32-C6 project on a clean PlatformIO environment (without `intelhex` pre-installed) and verify the build succeeds
- [ ] Build an ESP32-S3 project to confirm existing functionality is not affected
- [ ] Verify `rich_click` auto-install still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)