### PR TITLE
Fix: two macOS-specific failures when building projects through PIO IDE.

### DIFF
--- a/builder/frameworks/zephyr.py
+++ b/builder/frameworks/zephyr.py
@@ -62,7 +62,11 @@ if os.path.isdir(platform_boards_dir):
         dst = join(framework_boards_dir, board_name_dir)
         if not os.path.isdir(src):
             continue
-        if os.path.exists(dst) or os.path.islink(dst):
+        # Remove stale symlinks left by older platform versions, and skip
+        # if a real directory already exists (avoid clobbering on re-builds).
+        if os.path.islink(dst) and not os.path.exists(dst):
+            os.remove(dst)
+        elif os.path.exists(dst):
             continue
         shutil.copytree(src, dst)
         print(f"Copied board: {board_name_dir} -> {dst}")

--- a/builder/frameworks/zephyr.py
+++ b/builder/frameworks/zephyr.py
@@ -45,13 +45,18 @@ platform_dir = env.PioPlatform().get_dir()
 west_yml_path = join(framework_dir, "west.yml")
 hal_nordic_dir = join(framework_dir, "_pio", "modules", "hal", "nordic")
 
-# Symlink custom board definitions into Zephyr framework boards directory
+# Copy custom board definitions into Zephyr framework boards directory
 # so that Zephyr CMake can discover them during build configuration.
+# Note: We intentionally use copytree instead of symlink on all platforms.
+# Python's pathlib.Path.rglob() (used by Zephyr's list_boards.py) does not
+# follow symlink directories by default, which makes symlinked boards
+# invisible to CMake on macOS/Linux.
 platform_boards_dir = join(platform_dir, "zephyr", "boards", "arm")
 framework_boards_dir = join(framework_dir, "boards", "arm")
 
 if os.path.isdir(platform_boards_dir):
     os.makedirs(framework_boards_dir, exist_ok=True)
+    import shutil
     for board_name_dir in os.listdir(platform_boards_dir):
         src = join(platform_boards_dir, board_name_dir)
         dst = join(framework_boards_dir, board_name_dir)
@@ -59,13 +64,8 @@ if os.path.isdir(platform_boards_dir):
             continue
         if os.path.exists(dst) or os.path.islink(dst):
             continue
-        try:
-            os.symlink(src, dst)
-            print(f"Linked board: {board_name_dir} -> {src}")
-        except OSError:
-            import shutil
-            shutil.copytree(src, dst)
-            print(f"Copied board: {board_name_dir} -> {dst}")
+        shutil.copytree(src, dst)
+        print(f"Copied board: {board_name_dir} -> {dst}")
 
 import re
 import time

--- a/examples/zephyr-adc/zephyr/CMakeLists.txt
+++ b/examples/zephyr-adc/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-battery/zephyr/CMakeLists.txt
+++ b/examples/zephyr-battery/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble-lbs/lbs-central/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble-lbs/lbs-central/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble-lbs/lbs-peripheral/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble-lbs/lbs-peripheral/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-blink/zephyr/CMakeLists.txt
+++ b/examples/zephyr-blink/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-button/zephyr/CMakeLists.txt
+++ b/examples/zephyr-button/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-dmic-recorder/zephyr/CMakeLists.txt
+++ b/examples/zephyr-dmic-recorder/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-dmic/zephyr/CMakeLists.txt
+++ b/examples/zephyr-dmic/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/2inch13/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/2inch13/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/5inch83/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/5inch83/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/7inch5/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/7inch5/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/buzzer/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/buzzer/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/i2c-sht31/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/i2c-sht31/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/oled/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/oled/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/rtc/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/rtc/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/sd_card/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/sd_card/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-gpio/zephyr/CMakeLists.txt
+++ b/examples/zephyr-gpio/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-gps/zephyr/CMakeLists.txt
+++ b/examples/zephyr-gps/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-imu/zephyr/CMakeLists.txt
+++ b/examples/zephyr-imu/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-lowpower/zephyr/CMakeLists.txt
+++ b/examples/zephyr-lowpower/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-pwm/zephyr/CMakeLists.txt
+++ b/examples/zephyr-pwm/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-rfsw/zephyr/CMakeLists.txt
+++ b/examples/zephyr-rfsw/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-tapwake/zephyr/CMakeLists.txt
+++ b/examples/zephyr-tapwake/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-uart/zephyr/CMakeLists.txt
+++ b/examples/zephyr-uart/zephyr/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-xiao-round-display/watchface/zephyr/CMakeLists.txt
+++ b/examples/zephyr-xiao-round-display/watchface/zephyr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/Seeed Studio/zephyr")
+set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/platform.json
+++ b/platform.json
@@ -1,5 +1,5 @@
 {
-  "name": "Seeed Studio",
+  "name": "SeeedStudio",
   "title": "Seeed Studio Xiao Series",
   "description": "The Seeed Studio XIAO Series is a collection of thumb-sized, powerful microcontroller units (MCUs) tailor-made for space-conscious projects requiring high performance and wireless connectivity",
   "homepage": "https://wiki.seeedstudio.com/SeeedStudio_XIAO_Series_Introduction/",


### PR DESCRIPTION
### Problem 1: `No board named 'xiao_nrf54lm20a' found`

  Python's `pathlib.Path.rglob()` (used by Zephyr's `list_boards.py`) does **not** follow symlink directories by default. The previous code used `os.symlink` on macOS/Linux to expose custom board definitions to the Zephyr framework, making them invisible to CMake's board discovery.

  On Windows, `os.symlink` typically fails (requires admin privileges), so the code fell back to `shutil.copytree` — which worked correctly. This made the bug appear macOS/Linux-only.

  ### Problem 2: Kconfig truncates BOARD_ROOT path at space

  `platform.json` had `"name": "Seeed Studio"` (with a space), causing the installation path to be `~/.platformio/platforms/Seeed Studio/`. Zephyr's `kconfig.cmake` treats spaces as argument delimiters in Unix shells, truncating the path and failing with `File not found`.