### PR TITLE
fix(boards): swap blue/red LED GPIO pins on xiao_nrf54lm20a

### DIFF
--- a/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
+++ b/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
@@ -11,12 +11,12 @@
 		compatible = "gpio-leds";
 
 		blue_led: blue_led {
-			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 			label = "BLUE_LED";
 		};
 
 		red_led: red_led {
-			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 			label = "RED_LED";
 		};
 


### PR DESCRIPTION
Blue and red LED GPIO assignments were swapped on the XIAO nRF54LM20A. Blue is now on gpio1 23, red on gpio1 22.