### PR TITLE
fix: remove redundant BOARD_ROOT conflicting with copytree

### DIFF
--- a/examples/zephyr-adc/zephyr/CMakeLists.txt
+++ b/examples/zephyr-adc/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-battery/zephyr/CMakeLists.txt
+++ b/examples/zephyr-battery/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble-lbs/lbs-central/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble-lbs/lbs-central/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble-lbs/lbs-peripheral/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble-lbs/lbs-peripheral/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-ble/zephyr/CMakeLists.txt
+++ b/examples/zephyr-ble/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-blink/zephyr/CMakeLists.txt
+++ b/examples/zephyr-blink/zephyr/CMakeLists.txt
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
-
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)

--- a/examples/zephyr-button/zephyr/CMakeLists.txt
+++ b/examples/zephyr-button/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-dmic-recorder/zephyr/CMakeLists.txt
+++ b/examples/zephyr-dmic-recorder/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-dmic/zephyr/CMakeLists.txt
+++ b/examples/zephyr-dmic/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/2inch13/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/2inch13/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/5inch83/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/5inch83/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-epaper/7inch5/zephyr/CMakeLists.txt
+++ b/examples/zephyr-epaper/7inch5/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/buzzer/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/buzzer/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/i2c-sht31/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/i2c-sht31/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/oled/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/oled/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/rtc/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/rtc/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-expansion-base-for-xiao/sd_card/zephyr/CMakeLists.txt
+++ b/examples/zephyr-expansion-base-for-xiao/sd_card/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-gpio/zephyr/CMakeLists.txt
+++ b/examples/zephyr-gpio/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-gps/zephyr/CMakeLists.txt
+++ b/examples/zephyr-gps/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-imu/zephyr/CMakeLists.txt
+++ b/examples/zephyr-imu/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-lowpower/zephyr/CMakeLists.txt
+++ b/examples/zephyr-lowpower/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-pwm/zephyr/CMakeLists.txt
+++ b/examples/zephyr-pwm/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-rfsw/zephyr/CMakeLists.txt
+++ b/examples/zephyr-rfsw/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-tapwake/zephyr/CMakeLists.txt
+++ b/examples/zephyr-tapwake/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/examples/zephyr-uart/zephyr/CMakeLists.txt
+++ b/examples/zephyr-uart/zephyr/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
-
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(uart21-demo)

--- a/examples/zephyr-xiao-round-display/watchface/zephyr/CMakeLists.txt
+++ b/examples/zephyr-xiao-round-display/watchface/zephyr/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-set(BOARD_ROOT "$ENV{ZEPHYR_BASE}/../../platforms/SeeedStudio/zephyr")
 
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
The copytree board-copy mechanism (690c5c9) places custom board definitions under $ZEPHYR_BASE/boards/ where Zephyr's rglob discovers them. The per-example CMakeLists.txt BOARD_ROOT was a second path to the same definitions; both became visible after the symlink->copytree switch, causing "Board(s) defined multiple times" CMake errors and breaking all Zephyr CI.