### PR TITLE
Fix JLink upload offset address for nRF52840 (0x26000 -> 0x27000)

### DIFF
--- a/builder/board_build/nrf/nrf_build.py
+++ b/builder/board_build/nrf/nrf_build.py
@@ -480,7 +480,7 @@ elif upload_protocol.startswith("jlink"):
         commands = ["h"]
         if "DFUBOOTHEX" in env:
             commands.append("loadbin %s,%s" % (str(source).replace("_signature", ""),
-                env.BoardConfig().get("upload.offset_address", "0x26000")))
+                env.BoardConfig().get("upload.offset_address", "0x27000")))
             commands.append("loadbin %s,%s" % (source, env.get("BOOT_SETTING_ADDR")))
         else:
             commands.append("loadbin %s,%s" % (source, env.BoardConfig().get(


### PR DESCRIPTION
The JLink upload protocol was configured with an incorrect offset address of `0x26000`, causing the firmware image to be flashed at the wrong location.

The correct application start address is `0x27000`, as defined in the `nrf52840_s140_v7.ld` linker script:

```
# framework-arduinoadafruitnrf52-seeed/cores/nRF5/linker/nrf52840_s140_v7.ld
FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xED000 - 0x27000
```

This mismatch would result in a non-functional firmware image when uploading via JLink.

**Changes**
- Corrected `upload.offset_address` default from `0x26000` to `0x27000`