### PR TITLE
Fix KeyError for missing `upload.offset_address` board option

### DIFF
--- a/builder/board_build/nrf/nrf_build.py
+++ b/builder/board_build/nrf/nrf_build.py
@@ -59,7 +59,7 @@ variant = board.get("build.variant", "")
 
 
 def _get_dfu_upload_offset(board_config):
-    upload_offset = board_config.get("upload.offset_address")
+    upload_offset = board_config.get("upload.offset_address", None)
     if upload_offset:
         return upload_offset
 


### PR DESCRIPTION
### Background
I submitted a previous PR #50 hardcoding the DFU upload offset to `0x27000`, which broke boards using the `nrf52840_s140_v6.ld` linker script (correct offset `0x26000`). PR #51 dynamically resolves the offset from the board config and ldscript.

### Problem
PR #51 introduced a regression: when using `upload_protocol = jlink` and `board = seeed-xiao-afruitnrf52-nrf52840`, the build fails with:
```
*** [upload] KeyError "Invalid board option 'upload.offset_address'" trying to evaluate `${__jlink_cmd_script(__env__, SOURCE)}`
```
`board_config.get("upload.offset_address")` raises `KeyError` for boards that don't define `upload.offset_address`.

### Fix
Pass `None` explicitly as the default to `board_config.get("upload.offset_address", None)`, which prevents the `KeyError` and allows the ldscript-based offset detection from #51 to work as intended.