### PR TITLE
Fix invalid YAML on boards xiao_nrf54lm20a and xiao_nrf54lm20b

### DIFF
--- a/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.yaml
+++ b/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-identifier:xiao_nrf54lm20a/nrf54lm20a/cpuapp
+identifier: xiao_nrf54lm20a/nrf54lm20a/cpuapp
 name: XIAO nRF54LM20A-nRF54LM20A-Application
 type: mcu
 arch: arm

--- a/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
+++ b/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuflpr.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-identifier:xiao_nrf54lm20a/nrf54lm20a/cpuflpr
+identifier: xiao_nrf54lm20a/nrf54lm20a/cpuflpr
 name: XIAO nRF54LM20A-nRF54LM20A-Fast-Lightweight-Peripheral-Processor
 type: mcu
 arch: riscv

--- a/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20a_cpuapp.yaml
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20a_cpuapp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-identifier:xiao_nrf54lm20b/nrf54lm20a/cpuapp
+identifier: xiao_nrf54lm20b/nrf54lm20a/cpuapp
 name: XIAO nRF54LM20B-nRF54LM20A-Application
 type: mcu
 arch: arm

--- a/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20a_cpuflpr.yaml
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20a_cpuflpr.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-identifier:xiao_nrf54lm20b/nrf54lm20a/cpuflpr
+identifier: xiao_nrf54lm20b/nrf54lm20a/cpuflpr
 name: XIAO nRF54LM20B-nRF54LM20A-Fast-Lightweight-Peripheral-Processor
 type: mcu
 arch: riscv


### PR DESCRIPTION
Ran into issues with the YAML format on a few files when attempting to use twister.
```
yq . zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.yaml
Error: bad file 'zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a_cpuapp.yaml': yaml: line 2, column 5: mapping values are not allowed in this context
```