### PR TITLE
chore(skills): refine PlatformIO development and PR workflow

### DIFF
--- a/.agents/skills/platformio-development/SKILL.md
+++ b/.agents/skills/platformio-development/SKILL.md
@@ -1,25 +1,16 @@
 ---
 name: platformio-development
-description: Develop and validate behavior-changing work in the Seeed Studio PlatformIO platform through a developer-provided fork branch. Use when implementing or debugging board metadata, platform.py, SCons builders, framework integration, examples, CI scripts, or PlatformIO package-cache synchronization.
+description: Develop and validate behavior-changing work in the Seeed Studio PlatformIO platform through a stable developer fork branch and one synchronized local package-cache instance. Use when implementing or debugging board metadata, platform.py, SCons builders, framework integration, examples, CI scripts, or PlatformIO package-cache synchronization.
 ---
 
 # PlatformIO Development
 
-Apply the repository rules in `AGENTS.md` first. This skill defines the fork-based implementation and validation procedure for a PlatformIO behavior change.
+Apply the repository rules in `AGENTS.md` first. This skill ensures that platform source changes are applied correctly and consistently to the local PlatformIO package cache, and that local development uses one clear platform environment rather than multiple inconsistent copies.
 
-1. Before editing, require the developer to provide: fork URL, fork branch, sample directory, and PlatformIO environment. If any item is absent, ask for it and do not start implementation.
+1. Before editing, require the developer to provide: fork URL, a new branch based on the fork's `main`, sample directory, PlatformIO environment, and the local fork checkout path. If any item is absent, ask for it and do not start implementation. Keep the fork URL and branch stable for the whole development task.
 2. Identify the protected contract and the owning layer before choosing an implementation: board ID, framework selection, package version, upload/debug behavior, example path, or firmware artifact. Select the smallest sample and environment that exercise it.
-3. Temporarily change the target sample's `platformio.ini` so its `platform` entry references the declared fork and branch. Do not commit this test-only override or any local absolute path; restore it before preparing the upstream pull request.
-4. Make each coherent repository change on the local branch, inspect the diff, and commit the repository source changes locally. Push that commit to the declared fork branch before treating a fork-based sample build as validation. If pushing is not authorized, stop and report that remote-fork validation cannot proceed.
-5. Run `pio system info` and `pio pkg list -d <sample> --only-platforms -v`. Synchronize only the package-cache instance selected by that sample, and align it with the exact pushed fork revision. Do not guess a cache path, update a different cached platform, or use a broad recursive overwrite.
-6. Every time a sample compiles new firmware, run `pio run -d <sample> -e <environment> -t clean` first, then run the sample build. Validate changed JSON with `python -m json.tool <file>` and changed Python/SCons with `python -m compileall -q <paths>`.
-7. Treat a fix as valid only when a first-time PlatformIO user can fetch the declared fork branch and build the sample without local-only patches or fixed paths. If this cannot be demonstrated, state the missing validation and do not call the fix verified.
-8. Only after the developer explicitly confirms validation passed, manage the commit history before proposing a PR:
-   - keep the current branch checked out; do not create, rename, or switch branches;
-   - inspect the commits since the PR base and group changes by functional unit, such as one bug fix, one board/config change, one test/example change, or one documentation change;
-   - remove build-only, cache-only, and repeated verification commits from the final story by squashing or folding them into the functional commit they validate;
-   - show the proposed final commit list and obtain confirmation when a commit cannot be assigned unambiguously;
-   - rewrite only the current branch history with interactive rebase or an equivalent local operation;
-   - fetch the current remote branch OID before publishing and update the fork with `--force-with-lease`, never raw `--force`;
-   - re-check that the fork branch and selected PlatformIO package cache resolve to the final pushed commit.
-9. After the history is clean and the final fork revision is confirmed, ask for the pull-request base branch if it is unknown, then provide a prefilled PR compare URL and PR title/body. Use `https://github.com/Seeed-Studio/platform-seeedboards/compare/<base>...<fork-owner>:<branch>?quick_pull=1&title=<url-encoded-title>&body=<url-encoded-body>`; do not create the PR unless asked.
+3. Temporarily change the target sample's `platformio.ini` so its `platform` entry references the stable fork URL and branch, for example `https://github.com/<fork-owner>/platform-seeedboards.git#<branch>`. Do not use a changing commit SHA in this inner loop: each new Git commit reference creates a new `@src-<hash>` directory under the PlatformIO platforms cache. Do not commit this test-only override or any local absolute path; restore it before preparing the upstream pull request.
+4. Bootstrap the package once, then discover the selected package directory with `pio system info` and `pio pkg list -d <sample> --only-platforms -v`. Record that exact directory under `C:\Users\seeed\.platformio\platforms`; never guess from a directory name and never select a different `@src-*` copy.
+5. Immediately after changing any platform source file, apply the same change to the selected local PlatformIO platform package. Keep the fork checkout and that one cached package aligned before compiling. Do not modify other platform-cache copies, run `pio pkg update`, or change the fork branch/commit reference during the development loop.
+6. Every time a sample compiles new firmware, run `pio run -d <sample> -e <environment> -t clean` after synchronization, then run the sample build.
+7. When the developer explicitly asks to stage, commit, push, and create or update a GitHub pull request, invoke the `yeet` skill. It owns the Git and PR workflow.

--- a/.agents/skills/yeet/SKILL.md
+++ b/.agents/skills/yeet/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: "yeet"
+description: "Use only when the user explicitly asks to stage, commit, push, and open a GitHub pull request in one flow using the GitHub CLI (`gh`)."
+---
+
+## Prerequisites
+
+- Require GitHub CLI `gh`. Check `gh --version`. If missing, ask the user to install `gh` and stop.
+- Require authenticated `gh` session. Run `gh auth status`. If not authenticated, ask the user to run `gh auth login` (and re-run `gh auth status`) before continuing.
+
+## Naming conventions
+
+- Branch: `{description}` when starting from main/master/default.
+- Commit: `{description}` (terse).
+- PR title: `{description}` summarizing the full diff.
+
+## PR template discovery
+
+Before creating the PR, resolve the repository root and look for the active GitHub PR template from there:
+
+```shell
+repo_root="$(git rev-parse --show-toplevel)"
+```
+
+Template candidates, in order:
+
+- `.github/pull_request_template.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- One `*.md` file under `.github/pull_request_template/`
+- One `*.md` file under `.github/PULL_REQUEST_TEMPLATE/`
+
+Use paths as emitted from the repository root, such as `.github/pull_request_template.md`, not `./.github/pull_request_template.md`.
+
+If exactly one template is found, read it before composing the final PR body and pass it to `gh pr create` with `--template "$template"`.
+
+If multiple template files are found, stop before PR creation and ask which template to use. If no template exists, use the fallback body shape in this skill.
+
+## Workflow
+
+- If on main/master/default, create a branch: `git checkout -b "{description}"`
+- Otherwise stay on the current branch.
+- Confirm status, then stage everything: `git status -sb` then `git add -A`.
+- Commit tersely with the description: `git commit -m "{description}"`
+- Run checks if not already. If checks fail due to missing deps/tools, install dependencies and rerun once.
+- Push with tracking: `git push -u origin $(git branch --show-current)`
+- If git push fails due to workflow auth errors, pull from master and retry the push.
+- Discover and read the repository PR template, if any.
+- Check whether the current branch already has a PR: `gh pr view "$(git branch --show-current)" --json number,isDraft,url`
+- If a PR already exists, update that PR in place. Do not create another PR, and do not change whether the existing PR is draft or ready for review.
+- If no PR exists, open a new draft PR:
+  - With one template: `GH_PROMPT_DISABLED=1 GIT_TERMINAL_PROMPT=0 gh pr create --draft --fill --template "$template" --head "$(git branch --show-current)"`
+  - Without a template: `GH_PROMPT_DISABLED=1 GIT_TERMINAL_PROMPT=0 gh pr create --draft --fill --head "$(git branch --show-current)"`
+- Edit the PR title and body so they reflect the actual net change in the diff.
+- Write the PR description to a temp file with real newlines and pass it via `--body-file` or `gh pr edit --body-file` to avoid `\n`-escaped markdown.
+
+## Determining the PR
+
+When updating a PR created earlier in the flow, infer the PR from the current branch when possible:
+
+```shell
+git branch --show-current
+gh pr view "$(git branch --show-current)" --json number --jq '.number'
+```
+
+If this finds an existing PR, preserve its current review state. Never convert an existing ready-for-review PR back to draft as part of `yeet`; only new PRs created by this flow should start as draft.
+
+## PR Title
+
+Format: `<type>(<scope>): <subject>`
+
+`<scope>` is optional. A scope consist of a noun describing a section of the codebase (component, service or subsytem).
+
+### Example
+
+```
+feat: add hat wobble
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+```
+
+More Examples:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change)
+
+
+## PR Body Contents
+
+When invoked, use `gh` to edit the pull request body and title to reflect the contents of the specified PR. Make sure to check the existing pull request body to see if there is key information that should be preserved. For example, NEVER remove an image in the existing pull request body, as the author may have no way to recover it if you remove it.
+
+When a repository PR template exists, adapt the final PR body to that template. Preserve meaningful headings, required checklists, and repo-specific prompts, but replace placeholder text with net-diff-specific content or `N/A` where the template asks for it. Do not discard template sections just because the fallback shape below is shorter.
+
+It is critically important to explain _why_ the change is being made. If the current conversation in which this skill is invoked has discussed the motivation, be sure to capture this in the pull request body.
+
+The body should also explain _what_ changed, but this should appear after the _why_.
+
+Limit discussion to the _net change_ of the commit. It is generally frowned upon to discuss changes that were attempted but later undone in the course of the development of the pull request. When rewriting the pull request body, you may need to eliminate details such as these when they are no longer appropriate / of interest to future readers.
+
+Avoid references to absolute paths on my local disk. When talking about a path that is within the repository, simply use the repo-relative path.
+
+Default to omitting `Verification`. Add it only when you have behavioral evidence worth preserving for reviewers: a reproduced bug, a before/after check, a targeted test that exercises the changed behavior, or a manual scenario with input and observed outcome. Do not use it for generic commands or automation results such as package tests, type checks, linters, formatters, pre-commit/pre-push hooks, or CI status.
+
+If the repository template requires a validation or verification section, keep that section and avoid generic filler: include meaningful commands/results, a targeted manual scenario, or `Not run` with a reason.
+
+Use professional Markdown:
+
+- Put code, paths, commands, flags, and identifiers in backticks.
+- Use fenced code blocks for shell transcripts or multi-line examples.
+- Use GitHub permalinks when citing existing code relevant to the change.
+- Reference relevant issues or related PRs, but do not reference the PR in its own body.
+
+### Suggested PR Body Shape
+
+Use this as a fallback when the repository does not have a PR template:
+
+```markdown
+## Why
+
+Describe the user-facing or maintainer-facing problem, including cause and effect where useful.
+
+## What Changed
+
+Describe the net implementation change in concise prose.
+```


### PR DESCRIPTION
## Why

Platform source changes need to stay synchronized with one explicit local PlatformIO cache package so development does not create inconsistent platform copies. The repository also needs a shared PR workflow rather than relying on a developer-local Skill installation.

## What Changed

- Refined `platformio-development` around one stable fork branch, one selected cached platform package, immediate source-to-cache synchronization, and `clean + build` validation.
- Added the `yeet` Skill for the explicit stage, commit, push, and Draft PR workflow.