### PR TITLE
fix(nrf54lm20a): keep VSYS_3V3 enabled

### DIFF
--- a/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
+++ b/zephyr/boards/arm/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
@@ -78,6 +78,18 @@
 			regulators {
 				compatible = "nordic,npm1300-regulator";
 
+				/*
+				 * BUCK2 supplies VSYS_3V3, which powers both the nRF54
+				 * application and the SAMD11 USB debugger. Keep this rail
+				 * enabled during XIAO nRF54LM20A development; disabling it
+				 * also removes power from the USB debugger.
+				 */
+				vsys_3v3: BUCK2 {
+					regulator-always-on;
+					regulator-min-microvolt = <3300000>;
+					regulator-max-microvolt = <3300000>;
+				};
+
 				imu_vdd: dmic_vdd: LDO1 {
 					regulator-init-microvolt = <3300000>;
 					regulator-min-microvolt = <3300000>;


### PR DESCRIPTION
## Why

On XIAO nRF54LM20A, nPM1300 BUCK2 supplies `VSYS_3V3`, the shared upstream rail for the nRF54 application and the SAMD11 USB debugger. Disabling this rail prevents the USB debugger from enumerating.

## What Changed

Model BUCK2 as the `vsys_3v3` regulator in the XIAO nRF54LM20A board devicetree. Mark it `regulator-always-on` and constrain its valid output voltage to 3.3 V. The board-level comment documents why application firmware must not disable this rail.

## Verification

`pio run -e seeed-xiao-nrf54lm20a` in `examples/zephyr-lowpower` completed successfully. The generated devicetree contains the BUCK2 node, `regulator-always-on`, and the 3,300,000 µV limits.

Hardware validation was not performed.
