### PR TITLE
fix(oled): restore nRF54L15 SSD1306 binding

### DIFF
--- a/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/app.overlay
+++ b/examples/zephyr-expansion-base-for-xiao/oled-lvgl/zephyr/app.overlay
@@ -24,7 +24,7 @@
 	zephyr,concat-buf-size = <2048>;
 	zephyr,flash-buf-max-size = <2048>;
 	ssd1306_128x64: ssd1306@3c {
-		compatible = "solomon,ssd1306";
+		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
 		width = <128>;
 		height = <64>;

--- a/examples/zephyr-expansion-base-for-xiao/oled/zephyr/app.overlay
+++ b/examples/zephyr-expansion-base-for-xiao/oled/zephyr/app.overlay
@@ -9,7 +9,7 @@
 	zephyr,concat-buf-size = <2048>;
 	zephyr,flash-buf-max-size = <2048>;
 	ssd1306_128x64: ssd1306@3c {
-		compatible = "solomon,ssd1306";
+		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
 		width = <128>;
 		height = <64>;


### PR DESCRIPTION
## Why

The OLED examples use different Zephyr framework generations: nRF54LM20A uses Zephyr 4.4.0, while nRF54L15 uses Zephyr 4.2.1. The shared overlay was changed to the newer `solomon,ssd1306` binding, which is unavailable for the nRF54L15 framework and caused both nRF54L15 OLED CI builds to fail.

## What Changed

- Restore `solomon,ssd1306fb` in the shared OLED and OLED-LVGL overlays used by nRF54L15.
- Keep the nRF54LM20A board-specific overlays on `solomon,ssd1306`.

## Verification

- `oled` / `seeed-xiao-nrf54l15`: build passed.
- `oled-lvgl` / `seeed-xiao-nrf54l15`: build passed.
- `oled` / `seeed-xiao-nrf54lm20a`: build passed.
- `oled-lvgl` / `seeed-xiao-nrf54lm20a`: build passed.
