### PR TITLE
Fix nRF54L OpenOCD false-SUCCESS uploads; pin recovery tools to forked pyOCD

### DIFF
--- a/builder/board_build/nrf/nrf_build.py
+++ b/builder/board_build/nrf/nrf_build.py
@@ -822,14 +822,30 @@ elif upload_protocol in debug_tools:
         openocd_args.extend([
             "-c", "init; targets; halt; program {$SOURCE} verify reset; shutdown"
         ])
-    # 54l15 use hex to upload
+    # nRF54L RRAM uploads. A blank (mass-erased) chip has no vector table, so
+    # the core sits in LOCKUP when OpenOCD attaches; halt it before writing
+    # RRAM and verify the image afterwards. Without the verify a failed write
+    # still exits 0 and PlatformIO reports a false SUCCESS. See
+    # https://github.com/Seeed-Studio/platform-seeedboards/issues/69
     elif board.get("build.mcu") == "nrf54l15":
         openocd_args.extend([
-            "-c", "init; mww 0x5004b500 0x101; load_image {$SOURCE}; reset run; exit"
+            "-c", "init",
+            "-c", "reset halt",
+            "-c", "mww 0x5004b500 0x101; load_image {$SOURCE}",
+            "-c", "verify_image {$SOURCE}",
+            "-c", "reset run",
+            "-c", "shutdown"
         ])
     elif board.get("build.mcu") == "nrf54lm20a":
         openocd_args.extend([
-            "-c", "init; mww 0x5004e500 0x101; load_image {$SOURCE}; reset run; exit"
+            "-c", "init",
+            "-c", "reset halt",
+            # nrf54lm20a-load (defined in the board OpenOCD config) sets the
+            # RRAMC write-enable bit and writes the image straight into RRAM.
+            "-c", "nrf54lm20a-load {$SOURCE}",
+            "-c", "verify_image {$SOURCE}",
+            "-c", "reset run",
+            "-c", "shutdown"
         ])
     else:
        print("Warning! Uploading via OpenOCD is not yet supported for this MCU.")

--- a/scripts/factory_reset/factory_reset.bat
+++ b/scripts/factory_reset/factory_reset.bat
@@ -3,7 +3,9 @@ setlocal EnableDelayedExpansion
 
 set "SCRIPT_DIR=%~dp0"
 set "VENV_DIR=%SCRIPT_DIR%.venv"
-set "DEP_MARKER=%VENV_DIR%\.dependencies_installed"
+REM Bump the marker to force a reinstall from requirements.txt; older venvs
+REM still hold stock pyOCD, which faults on nRF54LM20A (issue #69).
+set "DEP_MARKER=%VENV_DIR%\.deps_forked_pyocd_v1"
 
 if not exist "%VENV_DIR%" (
     echo Creating Python virtual environment...
@@ -20,8 +22,8 @@ echo Activating virtual environment...
 call "%VENV_DIR%\Scripts\activate.bat"
 
 if not exist "%DEP_MARKER%" (
-    echo Installing dependencies...
-    pip install pyocd libusb  
+    echo Installing dependencies from requirements.txt...
+    pip install -r "%SCRIPT_DIR%requirements.txt"
     if not errorlevel 1 (
         echo. > "%DEP_MARKER%"
     )
@@ -53,7 +55,7 @@ if errorlevel 1 (
     set "VENV_DIR=%SCRIPT_DIR%.venv"
     if not exist "%VENV_DIR%" python -m venv "%VENV_DIR%"
     call "%VENV_DIR%\Scripts\activate.bat"
-    pip install pyocd   libusb >nul
+    pip install -r "%SCRIPT_DIR%requirements.txt" >nul
 )
 
 python "%SCRIPT_DIR%reset_tool.py" --mode factory --firmware "%FIRMWARE%" %EXTRA_ARGS%

--- a/scripts/factory_reset/factory_reset.sh
+++ b/scripts/factory_reset/factory_reset.sh
@@ -8,7 +8,9 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 FIRMWARE="${DIR}/firmware.hex"
 VENV_DIR="$DIR/.venv"
-DEP_MARKER="$VENV_DIR/.deps_installed"
+# Bump the marker to force a reinstall from requirements.txt; older venvs
+# still hold stock pyOCD, which faults on nRF54LM20A (issue #69).
+DEP_MARKER="$VENV_DIR/.deps_forked_pyocd_v1"
 REQ_PROBE="$1"
 EXTRA_ARGS=""
 if [ -n "$REQ_PROBE" ]; then
@@ -25,8 +27,8 @@ fi
 source "$VENV_DIR/bin/activate"
 
 if [ ! -f "$DEP_MARKER" ]; then
-    echo "[INFO] Installing dependencies into venv (pyocd libusb)..."
-    pip install pyocd libusb >/dev/null
+    echo "[INFO] Installing dependencies into venv (forked pyocd + libusb)..."
+    pip install -r "$DIR/requirements.txt" >/dev/null
     touch "$DEP_MARKER"
 else
     echo "[INFO] Dependencies already installed in venv."

--- a/scripts/factory_reset/recover_only.bat
+++ b/scripts/factory_reset/recover_only.bat
@@ -6,7 +6,9 @@ REM Recover-only wrapper
 REM ==============================================
 set "SCRIPT_DIR=%~dp0"
 set "VENV_DIR=%SCRIPT_DIR%.venv"
-set "DEP_MARKER=%VENV_DIR%\.deps_installed"
+REM Bump the marker to force a reinstall from requirements.txt; older venvs
+REM still hold stock pyOCD, which faults on nRF54LM20A (issue #69).
+set "DEP_MARKER=%VENV_DIR%\.deps_forked_pyocd_v1"
 set "ARG_PROBE=%~1"
 set "EXTRA_ARGS="
 if not "%ARG_PROBE%"=="" set "EXTRA_ARGS=--probe %ARG_PROBE%"
@@ -32,8 +34,8 @@ if errorlevel 1 (
 
 REM ---------- Install dependencies (once) ----------
 if not exist "%DEP_MARKER%" (
-  echo [INFO] Installing dependencies into venv (pyocd libusb)...
-  pip install pyocd libusb >nul
+  echo [INFO] Installing dependencies into venv (forked pyocd + libusb)...
+  pip install -r "%SCRIPT_DIR%requirements.txt" >nul
   if errorlevel 1 (
     echo [ERROR] Dependency installation failed.
     exit /b 1

--- a/scripts/factory_reset/recover_only.sh
+++ b/scripts/factory_reset/recover_only.sh
@@ -8,7 +8,9 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VENV_DIR="$DIR/.venv"
-DEP_MARKER="$VENV_DIR/.deps_installed"
+# Bump the marker to force a reinstall from requirements.txt; older venvs
+# still hold stock pyOCD, which faults on nRF54LM20A (issue #69).
+DEP_MARKER="$VENV_DIR/.deps_forked_pyocd_v1"
 REQ_PROBE="$1"
 EXTRA_ARGS=""
 if [ -n "$REQ_PROBE" ]; then
@@ -25,8 +27,8 @@ fi
 source "$VENV_DIR/bin/activate"
 
 if [ ! -f "$DEP_MARKER" ]; then
-  echo "[INFO] Installing dependencies into venv (pyocd libusb)..."
-  pip install pyocd libusb >/dev/null
+  echo "[INFO] Installing dependencies into venv (forked pyocd + libusb)..."
+  pip install -r "$DIR/requirements.txt" >/dev/null
   touch "$DEP_MARKER"
 else
   echo "[INFO] Dependencies already installed in venv."

--- a/scripts/factory_reset/requirements.txt
+++ b/scripts/factory_reset/requirements.txt
@@ -1,0 +1,13 @@
+# Dependencies for the factory-reset / recover tools, installed by the
+# wrapper scripts into scripts/factory_reset/.venv.
+#
+# pyOCD is pinned to the Seeed-supported fork that carries working nRF54LM20A
+# flash support. Stock pyOCD (0.44.x/0.45.x) faults inside its flash algorithm
+# on nRF54LM20A -- see pyocd/pyOCD#2016 and
+# Seeed-Studio/platform-seeedboards#69.
+#
+# KEEP IN SYNC with _ensure_pyocd_installed() in
+# builder/board_build/nrf/nrf_build.py, which installs the exact same fork
+# for the PlatformIO upload path.
+pyocd @ git+https://github.com/StarSphere-1024/pyOCD.git@lm20_stable
+libusb


### PR DESCRIPTION
Fixes #69 (platform side)

## What was wrong

Two independent defects combine into the reported "mass-erased board becomes unrecoverable while upload prints `[SUCCESS]`":

### 1. OpenOCD upload sequence — no halt, no verify (`builder/board_build/nrf/nrf_build.py`)

A freshly mass-erased nRF54L has no vector table, so the core comes up in LOCKUP when OpenOCD attaches — that is the `clearing lockup after double fault` / `Polling failed, trying to reexamine` in the issue log. The shipped sequence

```
init; mww 0x5004e500 0x101; load_image {$SOURCE}; reset run; exit
```

- never recovers the core from lockup before writing RRAM, and
- never verifies the write. OpenOCD's async poll errors do not affect the exit code, so a chip that was never actually programmed still exits 0 and PlatformIO prints `[SUCCESS]`.

The working sequence was already validated against hardware in pyocd/pyOCD#2016 — `init / reset halt / nrf54lm20a-load / verify_image / reset run / shutdown`, each command as its own `-c` argument (chaining with semicolons swallows the load/verify output). This PR adopts exactly that; the LM20A branch also reuses the `nrf54lm20a-load` proc from the board OpenOCD config instead of inlining the RRAMC WEN write. The nRF54L15 branch had the same defect (its default upload protocol is also cmsis-dap) and gets the same halt + verify treatment.

### 2. factory_reset venv installed stock pyOCD (`scripts/factory_reset/`)

Stock pyOCD 0.44.x/0.45.x faults inside its flash algorithm on nRF54LM20A (pyocd/pyOCD#2016) — which is why the builder path installs the fork (`StarSphere-1024/pyOCD@lm20_stable`) via `_ensure_pyocd_installed()`. The recovery wrappers were doing plain `pip install pyocd`, so the recovery tool itself ran the known-broken pyOCD: the reporter's crashing `pyocd.exe` came from this venv, and `reset_tool.py --mode factory` (erase + flash) would brick an LM20A by construction.

The wrappers now install from the new `scripts/factory_reset/requirements.txt`, pinning the **same fork ref** as the builder so both paths always use the same tool version. Dependency markers are bumped (`.deps_forked_pyocd_v1`) so existing venvs still holding stock pyOCD are rebuilt on the next run.

## Not in scope

- The upstream pyOCD flash-algorithm fault (pyocd/pyOCD#2016) — our pyOCD upload path uses the fork; an upstream fix is tracked separately.
- nRF54LM20B `cmsis-dap` upload (different image layout; default protocol is `nrfutil-mcumgr`) — handled in its own stream.

## Validation

- [ ] Blank-chip upload (the issue repro): `pyocd erase --chip -t nrf54lm20a` → `pio run -t upload` (cmsis-dap) → `verify_image` passes, board boots, serial output present
- [ ] Repeat on 3–5 boards
- [ ] Overwrite path (board already running firmware) still uploads fine
- [ ] `factory_reset` / `recover_only` rebuild the venv from requirements.txt; `reset_tool.py --mode factory --target nrf54lm20a` succeeds
- [ ] nRF54L15 smoke test (same sequence, inline RRAMC write)

Hardware validation pending — the sequence itself is the one already validated by the team in pyocd/pyOCD#2016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)