### PR TITLE
boards: zero-config NCS sysbuild defaults for xiao_nrf54lm20b USB DFU

### DIFF
--- a/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.defconfig
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.defconfig
@@ -12,6 +12,32 @@ config ROM_START_OFFSET
 config BOOTLOADER_MCUBOOT
 	default y if !MCUBOOT
 
+# The boot partition is 24K, so the mcuboot child image cannot afford the
+# serial/console subsystems (and with the USB stack already off in MCUboot
+# builds, the UART console points at the CDC ACM device with no driver behind
+# it: undefined __device_dts_ord reference at link time). The board
+# _defconfig therefore does not set SERIAL/CONSOLE/UART_CONSOLE explicitly,
+# and these defaults turn the CDC ACM serial backend off for MCUboot builds.
+# They precede the source line on purpose: Kconfig defaults are first-wins,
+# and zephyr's Kconfig.zephyr parses board Kconfig.defconfig files first so
+# they can override the defaults below.
+if MCUBOOT
+
+config SERIAL
+	default n
+
+config CONSOLE
+	default n
+
+# Must live here rather than in Kconfig.xiao_nrf54lm20b: Kconfig defaults are
+# first-wins, the board Kconfig.defconfig is parsed before the SoC defconfig
+# (which defaults CLOCK_CONTROL to y) but the board Kconfig is parsed after.
+config CLOCK_CONTROL
+	bool
+	default n
+
+endif # MCUBOOT
+
 source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
 
 # The cdc_acm_serial.defconfig sourced above enables SERIAL/CONSOLE/USB stack

--- a/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.sysbuild
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.sysbuild
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Seeed Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# XIAO nRF54LM20B ships from the factory with an MCUboot firmware-updater
+# bootloader (PURE Ed25519 signature verified through CRACEN/KMU, USB MCUmgr
+# loader entered with Button 0). These sysbuild defaults make a plain NCS
+# `west build` produce a matching signed application image with zero
+# per-application configuration, mirroring Nordic's Thingy:53 board model:
+#
+#   - MCUboot is rebuilt (users never flash it over USB DFU; the loader only
+#     writes the application slot) so sysbuild image signing kicks in with
+#     the factory key (root-ed25519.pem, the MCUboot module default).
+#   - Partition Manager is disabled: the fixed factory flash layout comes
+#     from the board devicetree (mcuboot 24K @0x0, slot0 1784K @0x6000,
+#     slot1 116K @0x1c4000, storage 16K).
+#   - The mcuboot child image picks up its board-specific config from
+#     mcuboot.conf in this directory.
+#
+# NOTE: this file is only evaluated by sysbuild (NCS west builds).
+# PlatformIO builds never read it and keep their own signing pipeline.
+
+if BOARD_XIAO_NRF54LM20B_NRF54LM20B_CPUAPP
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_FIRMWARE_UPDATER
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_ED25519
+endchoice
+
+config PARTITION_MANAGER
+	default n
+
+config MCUBOOT_SIGNATURE_USING_KMU
+	default y
+
+config BOOT_SIGNATURE_TYPE_PURE
+	default y
+
+endif # BOARD_XIAO_NRF54LM20B_NRF54LM20B_CPUAPP

--- a/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.xiao_nrf54lm20b
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.xiao_nrf54lm20b
@@ -25,6 +25,68 @@ config REGULATOR
 
 endif # !MCUBOOT
 
+if MCUBOOT
+
+# Entrance defaults for the factory firmware-loader bootloader. NCS sysbuild
+# maps MCUBOOT_MODE_FIRMWARE_UPDATER to BOOT_FIRMWARE_LOADER but leaves the
+# entrance mode to the board, and the mcuboot.conf next to this file is only
+# read by PlatformIO builds (sysbuild never puts it on the mcuboot child's
+# CONF_FILE chain). Without an entrance mode mcuboot fails to compile with
+# "Firmware loader selected without an entrance mode set" (io.c).
+config BOOT_FIRMWARE_LOADER_ENTRANCE_GPIO
+	bool
+	default y
+
+# The factory image additionally sets BOOT_FIRMWARE_LOADER_DETECT_DELAY=100
+# (Button 0 / P0.09 reads low transiently while VBUS and the power rails
+# rise). That default lives in mcuboot's Kconfig.firmware_loader, which is
+# the root Kconfig of the child image and parsed before any board file, so a
+# board-side default cannot override it; the rebuilt child is never flashed,
+# so the debounce window is inherited (0) instead.
+
+config BOOT_FIRMWARE_LOADER_NO_APPLICATION
+	bool
+	default y
+
+# Size optimizations so the bootloader fits the 24K boot partition, matching
+# the factory configuration (same levers as Nordic's nrf54l15dk setup in
+# nrf/samples/mcuboot/firmware_loader_entrance). Link-time optimization is
+# the main lever; local ISR table declaration is its companion.
+config LTO
+	bool
+	default y
+
+config ISR_TABLES_LOCAL_DECLARATION
+	bool
+	default y
+
+# Drop the boot banners, fatal-error reset handler and the libc malloc arena
+# from the child image. The clock-control driver is turned off in
+# Kconfig.defconfig (parse order); with no button debounce window (the
+# DETECT_DELAY default lives in mcuboot's root Kconfig and cannot be
+# overridden from the board) the child needs no system timer either.
+config BOOT_BANNER
+	bool
+	default n
+
+config RESET_ON_FATAL_ERROR
+	bool
+	default n
+
+config SYS_CLOCK_EXISTS
+	bool
+	default n
+
+config NRF_GRTC_TIMER
+	bool
+	default n
+
+config COMMON_LIBC_MALLOC_ARENA_SIZE
+	int
+	default 0
+
+endif # MCUBOOT
+
 if REGULATOR_NPM13XX
 
 # Both must stay after the charger (90) and INIT must stay greater than

--- a/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20b_cpuapp_defconfig
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/xiao_nrf54lm20b_nrf54lm20b_cpuapp_defconfig
@@ -1,12 +1,10 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-# Enable UART driver
-CONFIG_SERIAL=y
-
-# Enable console
-CONFIG_CONSOLE=y
-CONFIG_UART_CONSOLE=y
+# SERIAL/CONSOLE/UART_CONSOLE are intentionally not set here: the defaults in
+# boards/common/usb/Kconfig.cdc_acm_serial.defconfig enable them for normal
+# builds, and leaving them unset lets the mcuboot child image turn the serial
+# console off (24K boot partition; see Kconfig.defconfig in this directory).
 
 # USB CDC ACM serial backend is configured from Kconfig.defconfig via
 # boards/common/usb/Kconfig.cdc_acm_serial.defconfig.


### PR DESCRIPTION
Implements #85 (hardware DFU round-trip still pending — will confirm on the PR; keep the issue open until then) (hardware DFU round-trip still pending — will confirm on the PR).

## What

A plain NCS `west build` of **any** sample for `xiao_nrf54lm20b` — clean build dir, zero per-application configuration — now produces a factory-compatible `zephyr.signed.bin` that drops straight into the existing `xiao_nrf54lm20b_usb_dfu_flasher` flow, mirroring Nordic's Thingy:53 board model. PlatformIO builds are untouched.

## How (4 files)

| File | Role |
|---|---|
| `Kconfig.sysbuild` (new) | Sysbuild domain only (never evaluated by PlatformIO): MCUboot + `MCUBOOT_MODE_FIRMWARE_UPDATER`, Ed25519 **PURE** signing via **KMU**, partition manager off. No key distribution needed — the factory KMU public key is byte-identical to NCS's default `root-ed25519.pem`. |
| `Kconfig.xiao_nrf54lm20b` (`if MCUBOOT`) | Firmware-loader entrance defaults (`ENTRANCE_GPIO` + `NO_APPLICATION`): sysbuild maps FIRMWARE_UPDATER to `BOOT_FIRMWARE_LOADER` but leaves the entrance to the board, and the board `mcuboot.conf` is a PlatformIO-only convention sysbuild never reads. Plus size opts so the child fits the 24K boot partition: LTO + local ISR tables, no banners / fatal-error reset handler / malloc arena / GRTC system timer. |
| `Kconfig.defconfig` (`if MCUBOOT`) | `SERIAL`/`CONSOLE`/`CLOCK_CONTROL` off for MCUboot builds only: with the USB stack already off in MCUboot builds the CDC ACM console has no driver (undefined `__device_dts_ord` reference) and overflows the 24K partition. `CLOCK_CONTROL` must be defaulted here, before the SoC defconfig (Kconfig defaults are first-wins). |
| `_defconfig` | Dropped the explicit `SERIAL/CONSOLE/UART_CONSOLE` lines; normal builds get identical values from `boards/common/usb/Kconfig.cdc_acm_serial.defconfig` defaults, and MCUboot builds can now turn the console off. |

## Verified (NCS v3.3.0, clean dir, stock blinky, zero extra args)

- Build succeeds; `zephyr.signed.bin` + `dfu_application.zip` produced
- App `.config`: `FLASH_LOAD_OFFSET=0x6000`, `FLASH_LOAD_SIZE=0x1be000`, PM off; app console still on
- mcuboot child: `BOOT_FIRMWARE_LOADER` + entrance GPIO + no-application + PURE + Ed25519 + KMU
- imgtool actual args: `--pure --header-size 0x800 --slot-size 0x1be000 --overwrite-only --align 1`
- TLVs of the signed image: `SHA512(0x12) + SIG_PURE(0x25) + KEYHASH(0x01, 64B, e3e129b4…) + ED25519(0x24)` — key hash identical to the shipped bootloader's KMU key
- `imgtool verify` passes against NCS's stock `root-ed25519.pem`

## Known trade-offs (board-level Kconfig cannot override defaults in mcuboot's root Kconfig, which the child parses first; the rebuilt bootloader is never flashed over USB DFU)

- `BOOT_FIRMWARE_LOADER_DETECT_DELAY` stays 0 (factory uses 100 ms debounce against a transient low on P0.09 while power rails rise)
- No `FPROTECT`, no retention `BOOT_MODE` entrance (factory has both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)