### PR TITLE
docs(boards): fix stale mcuboot.conf/sysbuild-loading comments from #86

### DIFF
--- a/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.sysbuild
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/Kconfig.sysbuild
@@ -13,11 +13,21 @@
 #   - Partition Manager is disabled: the fixed factory flash layout comes
 #     from the board devicetree (mcuboot 24K @0x0, slot0 1784K @0x6000,
 #     slot1 116K @0x1c4000, storage 16K).
-#   - The mcuboot child image picks up its board-specific config from
-#     mcuboot.conf in this directory.
+#   - The mcuboot child image gets its board-specific config (firmware-loader
+#     entrance, 24K size levers) from the `if MCUBOOT` defaults in
+#     Kconfig.xiao_nrf54lm20b / Kconfig.defconfig: sysbuild does NOT load the
+#     mcuboot.conf in this directory -- that file is a PlatformIO-build
+#     convention only (the child's CONF_FILE chain is mcuboot's own
+#     prj.conf + SoC conf).
 #
 # NOTE: this file is only evaluated by sysbuild (NCS west builds).
 # PlatformIO builds never read it and keep their own signing pipeline.
+#
+# WARNING: the rebuilt mcuboot child is a build artifact for signing config
+# only. It is NOT the factory bootloader (no Button-0 debounce window, no
+# serial). `west flash` over a debug probe would program it over the factory
+# bootloader -- update applications through USB DFU (zephyr.signed.bin)
+# instead, or flash only the application image.
 
 if BOARD_XIAO_NRF54LM20B_NRF54LM20B_CPUAPP
 

--- a/zephyr/boards/arm/xiao_nrf54lm20b/mcuboot.conf
+++ b/zephyr/boards/arm/xiao_nrf54lm20b/mcuboot.conf
@@ -1,9 +1,12 @@
 # Copyright (c) 2025 Seeed Technology Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 #
-# MCUboot configuration for XIAO nRF54LM20B board.
-# This file is automatically loaded by Zephyr sysbuild when building
-# for this board with MCUboot enabled.
+# MCUboot configuration for the XIAO nRF54LM20B board.
+# PlatformIO-build convention: the platform builder puts this file on the
+# mcuboot child's CONF_FILE chain. NCS sysbuild does NOT load it (the child
+# chain is mcuboot's own prj.conf + SoC conf); for NCS the equivalent
+# defaults live in the `if MCUBOOT` blocks of Kconfig.xiao_nrf54lm20b /
+# Kconfig.defconfig.
 
 # ── Firmware-loader recovery ──
 


### PR DESCRIPTION
Comment-only follow-up to #86 (code review findings).

- `Kconfig.sysbuild`: the merged comment claimed the mcuboot child "picks up its board-specific config from mcuboot.conf in this directory" — wrong: NCS sysbuild never puts board-dir `mcuboot.conf` on the child's CONF_FILE chain (PlatformIO-build convention only; verified against the child's CONF_FILE in a sysbuild build). The child's board config actually comes from the `if MCUBOOT` defaults in `Kconfig.xiao_nrf54lm20b` / `Kconfig.defconfig`. Aligned the comment with that mechanism.
- `mcuboot.conf`: header made the matching false claim ("automatically loaded by Zephyr sysbuild"); now documents the PlatformIO-only scope and points NCS users at the Kconfig defaults.
- `Kconfig.sysbuild`: added a warning that the rebuilt mcuboot child is a signing-config artifact, **not** the factory bootloader (no Button-0 debounce, no serial) — `west flash` over a debug probe must not program it over the factory bootloader; applications are updated via USB DFU (`zephyr.signed.bin`).

No code/Kconfig behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)